### PR TITLE
Limit name replacement for modified tables to the first instance

### DIFF
--- a/squeeql/migrator.py
+++ b/squeeql/migrator.py
@@ -178,8 +178,9 @@ class DBMigrator:
             create_table_sql = pristine_tables[tbl_name]
             create_table_sql = re.sub(
                 r"\b%s\b" % re.escape(tbl_name),
-                tbl_name + "_migration_new",
+                f"{tbl_name}_migration_new",
                 create_table_sql,
+                count=1,
             )
             self.log_execute(
                 f"Columns change: Create table {tbl_name} with updated schema",

--- a/squeeql/tests/test_migrator.py
+++ b/squeeql/tests/test_migrator.py
@@ -104,6 +104,14 @@ _TEST_SCHEMAS = [
         active BOOLEAN NOT NULL DEFAULT(2));
     CREATE UNIQUE INDEX Node_node_id on Node(node_id);
     """,
+    # 6
+    # Create a table containing a column of the same name
+    """\
+    CREATE TABLE Name(
+        id INTEGER PRIMARY KEY NOT NULL,
+        Name TEXT NOT NULL
+    );
+    """,
 ]
 
 
@@ -163,6 +171,9 @@ class MigratorTestCase(unittest.TestCase):
             (3, 2, False),
             (3, 3, False),
             (3, 4, False),
+            (0, 6, False),
+            (6, 6, False),
+            (6, 0, True),
         ]
     )
     def test_dumb_schema_migration(


### PR DESCRIPTION
Only substitute the first instance of the table name in the CREATE TABLE statment when creating a cloned table for migrations, as a table may contain a column with the same name as the table.

Fixes #1